### PR TITLE
Ancient upgrade

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -9,6 +9,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
+
 (defn run []
     (figwheel/start-figwheel!))
 

--- a/project.clj
+++ b/project.clj
@@ -81,16 +81,16 @@
              {
               :source-paths ["dev"]
               :dependencies [[binaryage/devtools "0.9.10"]
-                             [figwheel "0.5.2"]
-                             [figwheel-sidecar "0.5.2"]
-                             [pjstadig/humane-test-output "0.9.0"]
-                             [prone "1.6.1"]
-                             [com.cemerick/piggieback "0.2.1"]
-                             [org.clojure/tools.nrepl "0.2.12"]
-                             [org.clojure/tools.namespace "0.2.3"]
-                             [org.clojure/java.classpath "0.2.0"]]
+                             [figwheel "0.5.19"]
+                             [figwheel-sidecar "0.5.19"]
+                             [pjstadig/humane-test-output "0.10.0"]
+                             [prone "2019-07-08"]
+                             [com.cemerick/piggieback "0.2.2"]
+                             [org.clojure/tools.nrepl "0.2.13"]
+                             [org.clojure/tools.namespace "0.3.1"]
+                             [org.clojure/java.classpath "0.3.0"]]
 
-              :plugins [[lein-figwheel "0.5.2"]
+              :plugins [[lein-figwheel "0.5.19"]
                         [lein-doo "0.1.6"]]
 
               :cljsbuild {:builds

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,14 @@
                  [com.multunus/dashboard-clj "0.1.0-SNAPSHOT"]
                  [cljsjs/highcharts "7.0.3-0"]
                  [cljsjs/jquery "3.4.0-0"]]
-                 ;[org.webjars.npm/bulma "0.7.5"]]
+  ;[org.webjars.npm/bulma "0.7.5"]]
 
   :min-lein-version "2.6.1"
 
   :source-paths ["src/clj" "src/cljs"]
-
   :test-paths ["test/clj"]
+  :resource-paths ["resources" "target/cljsbuild"]
+  :target-path "target/%s/"
 
   :clean-targets ^{:protect false} [:target-path :compile-path "resources/public/js"]
 
@@ -27,6 +28,8 @@
   ;; (browser-repl) live.
   :repl-options {:init-ns user}
 
+  :plugins [[lein-cljsbuild "1.1.7"]]
+
   :cljsbuild {:builds
               {:app
                {:source-paths ["src/cljs"]
@@ -35,10 +38,10 @@
                 ;; Alternatively, you can configure a function to run every time figwheel reloads.
                 ;; :figwheel {:on-jsload "vanilla.core/on-figwheel-reload"}
 
-                :compiler     {:main vanilla.core
-                               :asset-path "js/compiled/out"
-                               :output-to "resources/public/js/compiled/app.js"
-                               :output-dir "resources/public/js/compiled/out"
+                :compiler     {:main                 vanilla.core
+                               :asset-path           "js/compiled/out"
+                               :output-to            "resources/public/js/compiled/app.js"
+                               :output-dir           "resources/public/js/compiled/out"
                                :source-map-timestamp true}}}}
 
   ;; When running figwheel from nREPL, figwheel will read this configuration
@@ -47,9 +50,9 @@
   ;; not be picked up, instead configure figwheel here on the top level.
 
   :figwheel {;; :http-server-root "public"       ;; serve static assets from resources/public/
-             :server-port 3469                ;; default
+             :server-port    3469                           ;; default
              ;; :server-ip "127.0.0.1"           ;; default
-             :css-dirs ["resources/public/css"]  ;; watch and update CSS
+             :css-dirs       ["resources/public/css"]       ;; watch and update CSS
 
              ;; Instead of booting a separate server on its own port, we embed
              ;; the server ring handler inside figwheel's http-kit server, so
@@ -76,30 +79,26 @@
 
   :doo {:build "test"}
 
-  :profiles {:dev
+  :profiles {:dev     {:source-paths ["dev"]
+                       :dependencies [[binaryage/devtools "0.9.10"]
+                                      [figwheel "0.5.2"]
+                                      [figwheel-sidecar "0.5.2"]
+                                      [pjstadig/humane-test-output "0.10.0"]
+                                      [prone "2019-07-08"]
+                                      [com.cemerick/piggieback "0.2.2"]
+                                      [org.clojure/tools.nrepl "0.2.13"]
+                                      [org.clojure/tools.namespace "0.3.1"]
+                                      [org.clojure/java.classpath "0.3.0"]]
 
-             {
-              :source-paths ["dev"]
-              :dependencies [[binaryage/devtools "0.9.10"]
-                             [figwheel "0.5.2"]
-                             [figwheel-sidecar "0.5.2"]
-                             [pjstadig/humane-test-output "0.10.0"]
-                             [prone "2019-07-08"]
-                             [com.cemerick/piggieback "0.2.2"]
-                             [org.clojure/tools.nrepl "0.2.13"]
-                             [org.clojure/tools.namespace "0.3.1"]
-                             [org.clojure/java.classpath "0.3.0"]]
+                       :plugins      [[lein-figwheel "0.5.2"]
+                                      [lein-doo "0.1.6"]]
 
-              :plugins [[lein-figwheel "0.5.2"]
-                        [lein-doo "0.1.6"]]
-
-              :cljsbuild {:builds
-                          {:test
-                           {:source-paths ["src/cljs" "test/cljs"]
-                            :compiler
-                            {:output-to "resources/public/js/compiled/testable.js"
-                             :main vanilla.test-runner
-                             :optimizations :none}}}}}
+                       :cljsbuild    {:builds
+                                      {:test
+                                       {:source-paths ["src/cljs" "test/cljs"]
+                                        :compiler     {:output-to     "resources/public/js/compiled/testable.js"
+                                                       :main          vanilla.test-runner
+                                                       :optimizations :none}}}}}
 
              :uberjar {:omit-source  true
                        :prep-tasks   ["compile" ["cljsbuild" "once" "min"]]

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
                  [org.clojure/clojurescript "1.8.40" :scope "provided"]
                  [environ "1.0.2"]
                  [com.multunus/dashboard-clj "0.1.0-SNAPSHOT"]
-                 [cljsjs/highcharts "4.2.2-2"]
-                 [cljsjs/jquery "1.11.3-0"]
+                 [cljsjs/highcharts "7.0.3-0"]
+                 [cljsjs/jquery "3.4.0-0"]
                  [org.webjars.npm/bulma "0.7.5"]]
 
   :min-lein-version "2.6.1"

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
                  [environ "1.0.2"]
                  [com.multunus/dashboard-clj "0.1.0-SNAPSHOT"]
                  [cljsjs/highcharts "7.0.3-0"]
-                 [cljsjs/jquery "3.4.0-0"]
-                 [org.webjars.npm/bulma "0.7.5"]]
+                 [cljsjs/jquery "3.4.0-0"]]
+                 ;[org.webjars.npm/bulma "0.7.5"]]
 
   :min-lein-version "2.6.1"
 
@@ -81,8 +81,8 @@
              {
               :source-paths ["dev"]
               :dependencies [[binaryage/devtools "0.9.10"]
-                             [figwheel "0.5.19"]
-                             [figwheel-sidecar "0.5.19"]
+                             [figwheel "0.5.2"]
+                             [figwheel-sidecar "0.5.2"]
                              [pjstadig/humane-test-output "0.10.0"]
                              [prone "2019-07-08"]
                              [com.cemerick/piggieback "0.2.2"]
@@ -90,7 +90,7 @@
                              [org.clojure/tools.namespace "0.3.1"]
                              [org.clojure/java.classpath "0.3.0"]]
 
-              :plugins [[lein-figwheel "0.5.19"]
+              :plugins [[lein-figwheel "0.5.2"]
                         [lein-doo "0.1.6"]]
 
               :cljsbuild {:builds
@@ -101,16 +101,19 @@
                              :main vanilla.test-runner
                              :optimizations :none}}}}}
 
-             :uberjar
-             {:source-paths ^:replace ["src/clj"]
-              :hooks [leiningen.cljsbuild]
-              :omit-source true
-              :aot :all
-              :cljsbuild {:builds
-                          {:app
-                           {
-                            :source-paths ^:replace ["src/cljs"]
-                            :compiler
-                            {:optimizations :advanced
-                             :pretty-print false
-                             :pseudo-names true}}}}}})
+             :uberjar {:omit-source  true
+                       :prep-tasks   ["compile" ["cljsbuild" "once" "min"]]
+                       :cljsbuild    {:builds
+                                      {:min
+                                       {:source-paths ["src/cljc" "src/cljs"]
+                                        :compiler     {:output-dir       "target/cljsbuild/public/js/compiled"
+                                                       :output-to        "target/cljsbuild/public/js/compiled/app.js"
+                                                       :source-map       "target/cljsbuild/public/js/compiled/app.js.map"
+                                                       :optimizations    :advanced
+                                                       :pretty-print     false
+                                                       :infer-externs    true
+                                                       :closure-warnings {:externs-validation :off
+                                                                          :non-standard-jsdoc :off}}}}}
+
+                       :aot          :all
+                       :uberjar-name "vanilla.jar"}})

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -21,9 +21,3 @@ body {
     padding: 10px;
 }
 
-.simple-text-widget .data {
-    transform: translateX(-50%) translateY(-50%);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-}

--- a/src/cljs/vanilla/core.cljs
+++ b/src/cljs/vanilla/core.cljs
@@ -67,6 +67,8 @@
                                    :y-title      "power"
                                    :banner-color "yellow"
                                    :style-name   "widget"
+                                   :animation    false
+                                   :tooltip      {:followPointer true}
                                    :height       "500px"}}}
 
               {:type        :simple-text
@@ -94,7 +96,8 @@
                                    :slice-at 50}
                              :viz {:title        "Usage Data (side-by-side)"
                                    :banner-color "lavender"
-                                   :animation    false}}}])
+                                   :animation    false
+                                   :tooltip      {:followPointer true}}}}])
 
 
 

--- a/src/cljs/vanilla/core.cljs
+++ b/src/cljs/vanilla/core.cljs
@@ -28,8 +28,8 @@
                                    :line-width   0.5
                                    :animation    false
                                    :style-name   "widget"
-                                   :height       "575px"
                                    :tooltip      {:followPointer true}}}}
+                                   ;:debug        true}}}
 
               {:type        :line-chart
                :name        :spectrum-line-widget
@@ -48,9 +48,9 @@
                                    :line-width   0.5
                                    :animation    false
                                    :style-name   "widget"
-                                   :height       "575px"
                                    :tooltip      {:followPointer true}
                                    :icon         "timeline"}}}
+                                   ;:debug        true}}}
 
               {:type        :bar-chart
                :name        :spectrum-bar-widget
@@ -68,15 +68,15 @@
                                    :banner-color "yellow"
                                    :style-name   "widget"
                                    :animation    false
-                                   :tooltip      {:followPointer true}
-                                   :height       "500px"}}}
+                                   :tooltip      {:followPointer true}}}}
+                                   ;:debug        true}}}
 
               {:type        :simple-text
                :name        :time-widget
                :data-source :current-time
                :options     {:viz {:title        "Current Time"
                                    :banner-color "lightblue"
-                                   :style        {:paddingTop "15px"}
+                                   :style        {:display :flex :align-items :center}
                                    :height       "100px"}}}
 
               {:type        :pie-chart
@@ -87,6 +87,7 @@
                              :viz {:title        "Usage Data"
                                    :banner-color "goldenrod"
                                    :animation    false}}}
+                                   ;:debug        true}}}
 
               {:type        :side-by-side-chart
                :name        :usage-side-by-side-widget
@@ -98,6 +99,7 @@
                                    :banner-color "lavender"
                                    :animation    false
                                    :tooltip      {:followPointer true}}}}])
+                                   ;:debug        true}}}])
 
 
 

--- a/src/cljs/vanilla/core.cljs
+++ b/src/cljs/vanilla/core.cljs
@@ -76,7 +76,7 @@
                :data-source :current-time
                :options     {:viz {:title        "Current Time"
                                    :banner-color "lightblue"
-                                   :style        {:display :flex :align-items :center}
+                                   :style        {}
                                    :height       "100px"}}}
 
               {:type        :pie-chart

--- a/src/cljs/vanilla/widgets/bar_chart.cljs
+++ b/src/cljs/vanilla/widgets/bar_chart.cljs
@@ -29,7 +29,7 @@
   (let [config     (-> this r/props :chart-options)
         all-config (merge bar-chart-config config)]
 
-    (.log js/console (str "plt-bar " all-config))
+    (.log js/console (str "plot-bar " all-config))
 
     (.highcharts (js/$ (r/dom-node this))
                  (clj->js all-config))))
@@ -59,10 +59,12 @@
                      :color      (get-in options [:viz :line-colors])
                      :categories (into [] (map str (range (count (:values (first dats))))))}
 
-       :plotOptions {:series  {:animation (-> options :viz :animation)}
-                     :tooltip (-> options :viz :tooltip)
+       :plotOptions {:series  {:animation (get-in options [:viz :animation] false)}
+                     :tooltip (get-in options [:viz :tooltip] {})
                      :column  {:pointPadding 0.2
-                               :borderWidth  0}}
+                               :borderWidth  0
+                               :dataLabels {:enabled
+                                            (get-in options [:viz :data-labels] false)}}}
 
        :series      series}}]))
 

--- a/src/cljs/vanilla/widgets/bar_chart.cljs
+++ b/src/cljs/vanilla/widgets/bar_chart.cljs
@@ -70,8 +70,7 @@
 (widget-common/register-widget
   :bar-chart
   (fn [data options]
-    (let [dats (get-in data [:data (get-in options [:src :extract])])
-          num  (count dats)]
+    (let []
 
       [basic/basic-widget data options
        [:div {:style {:width "95%" :height "100%"}}

--- a/src/cljs/vanilla/widgets/bar_chart.cljs
+++ b/src/cljs/vanilla/widgets/bar_chart.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+    ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]
             [vanilla.widgets.basic-widget :as basic]
             [vanilla.widgets.util :as util]))
@@ -14,15 +14,16 @@
 
 
 (def bar-chart-config
-  {:chart {:type            :column
-           :backgroundColor "transparent"
+  {:chart   {:type            :column
+             :backgroundColor "transparent"
 
-           :style           {:labels {
-                                      :fontFamily "monospace"
-                                      :color      "#FFFFFF"}}}
-   :yAxis {:title  {:style {:color "#000000"}}
-           :labels {:color "#ffffff"}}
-   :xAxis {:labels {:style {:color "#fff"}}}})
+             :style           {:labels {
+                                        :fontFamily "monospace"
+                                        :color      "#FFFFFF"}}}
+   :credits {:enabled false}
+   :yAxis   {:title  {:style {:color "#000000"}}
+             :labels {:color "#ffffff"}}
+   :xAxis   {:labels {:style {:color "#fff"}}}})
 
 
 (defn- plot-bar [this]
@@ -31,8 +32,8 @@
 
     (.log js/console (str "plot-bar " all-config))
 
-    (.highcharts (js/$ (r/dom-node this))
-                 (clj->js all-config))))
+    (js/Highcharts.Chart. (r/dom-node this)
+                          (clj->js all-config))))
 
 
 (defn bar-chart
@@ -63,8 +64,8 @@
                      :tooltip (get-in options [:viz :tooltip] {})
                      :column  {:pointPadding 0.2
                                :borderWidth  0
-                               :dataLabels {:enabled
-                                            (get-in options [:viz :data-labels] false)}}}
+                               :dataLabels   {:enabled
+                                              (get-in options [:viz :data-labels] false)}}}
 
        :series      series}}]))
 

--- a/src/cljs/vanilla/widgets/basic_widget.cljs
+++ b/src/cljs/vanilla/widgets/basic_widget.cljs
@@ -19,7 +19,12 @@
           :style {:width "100%"
                   :height "40%"
                   :marginRight "50px"
-                  :marginTop "25px"}}
+                  :marginTop "25px"
+                  :cursor :default
+                  :border-style (if (get-in options [:viz :debug] false)
+                                  :dotted
+                                  :none)}
+          :on-mouse-down #(.stopPropagation %)}
 
     custom-content]])
 

--- a/src/cljs/vanilla/widgets/basic_widget.cljs
+++ b/src/cljs/vanilla/widgets/basic_widget.cljs
@@ -2,13 +2,15 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+            ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]))
 
 
 
 (defn basic-widget [data options custom-content]
-  [:div {:class "chart" :style {:height (get-in options [:viz :height]) :width "100%"}}
+  [:div {:class "chart container"
+         :style {:height (get-in options [:viz :height] "100%")
+                 :width "100%"}}
    [:div {:class "title-wrapper"}
     [:h3 {:class "title"
           :style {:background-color
@@ -17,13 +19,15 @@
 
    [:div {:class (str (get-in options [:viz :style-name] "widget"))
           :style {:width "100%"
-                  :height "40%"
+                  :height "80%"
                   :marginRight "50px"
-                  :marginTop "25px"
+                  :marginTop "5px"
                   :cursor :default
                   :border-style (if (get-in options [:viz :debug] false)
                                   :dotted
-                                  :none)}
+                                  :none)
+                  :align-items :stretch
+                  :display :flex}
           :on-mouse-down #(.stopPropagation %)}
 
     custom-content]])

--- a/src/cljs/vanilla/widgets/chart.cljs
+++ b/src/cljs/vanilla/widgets/chart.cljs
@@ -52,8 +52,9 @@
          :yAxis       {:title {:text (get-in options [:viz :y-title] "y-axis")}}
 
          :plotOptions {:line    {:lineWidth (get-in options [:viz :line-width] 1)}
-                       :series  {:animation (-> options :viz :animation)}
-                       :tooltip (-> options :viz :tooltip)}
+                       :series  {:animation (get-in options [:viz :animation] false)}
+                       :tooltip (get-in options [:viz :tooltip] {})}
+
 
          :series      (into []
                             (for [n (range num)]

--- a/src/cljs/vanilla/widgets/chart.cljs
+++ b/src/cljs/vanilla/widgets/chart.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+    ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]
             [vanilla.widgets.basic-widget :as basic]))
 
@@ -12,22 +12,25 @@
   [:div {:style {:width "100%" :height "100%"}}])
 
 (def line-chart-config
-  {:chart {:type            :line
-           :backgroundColor "transparent"
-
-           :style           {:labels {
-                                      :fontFamily "monospace"
-                                      :color      "#FFFFFF"}}}
-   :yAxis {:title  {:style {:color "#000000"}}
-           :labels {:color "#ffffff"}}
-   :xAxis {:labels {:style {:color "#fff"}}}})
+  {:chart   {:type            :line
+             :backgroundColor "transparent"
+             :style           {:labels {
+                                        :fontFamily "monospace"
+                                        :color      "#FFFFFF"}}}
+   :yAxis   {:title  {:style {:color "#000000"}}
+             :labels {:color "#ffffff"}}
+   :xAxis   {:labels {:style {:color "#fff"}}}
+   :credits {:enabled false}})
 
 
 (defn- plot-line [this]
   (let [config     (-> this r/props :chart-options)
         all-config (merge line-chart-config config)]
-    (.highcharts (js/$ (r/dom-node this))
-                 (clj->js all-config))))
+
+    (.log js/console (str "plot-line "))
+
+    (js/Highcharts.Chart. (r/dom-node this)
+                          (clj->js all-config))))
 
 (defn line-chart
   [chart-options]
@@ -58,16 +61,16 @@
 
          :series      (into []
                             (for [n (range num)]
-                              {:name  (get-in dats [n (get-in options [:src :name] :name)] (str "set " n))
-                               :data  (into [] (get-in dats [n (get-in options [:src :values] :values)]))}))}}])))
+                              {:name (get-in dats [n (get-in options [:src :name] :name)] (str "set " n))
+                               :data (into [] (get-in dats [n (get-in options [:src :values] :values)]))}))}}])))
 
 
 (widget-common/register-widget
   :line-chart
   (fn [data options]
 
-      [basic/basic-widget data options
+    [basic/basic-widget data options
 
-       [:div {:style {:width "95%" :height "100%"}}
+     [:div {:style {:width "95%" :height "100%"}}
 
-        [embed-line data options]]]))
+      [embed-line data options]]]))

--- a/src/cljs/vanilla/widgets/dual_chart.cljs
+++ b/src/cljs/vanilla/widgets/dual_chart.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+            ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]
             [vanilla.widgets.basic-widget :as basic]
             [vanilla.widgets.util :as util]
@@ -16,9 +16,10 @@
   (fn [data options]
     [basic/basic-widget data options
 
-     [:div {:style {:width "95%" :height "80%"}}
+     [:div {:style {:width "95%" :height "65%"}}
       [line/embed-line data options]
 
-      [bar/embed-bar data options (util/line->bar data options)]]]))
+      [:div {:style {:width "95%" :height "65%"}}
+       [bar/embed-bar data options (util/line->bar data options)]]]]))
 
 

--- a/src/cljs/vanilla/widgets/pie_chart.cljs
+++ b/src/cljs/vanilla/widgets/pie_chart.cljs
@@ -26,7 +26,12 @@
 
 (defn- plot-pie [this]
   (let [config     (-> this r/props :chart-options)
-        all-config (merge pie-chart-config config)]
+        render-to  {:render-to (r/dom-node this)}
+        all-config (merge pie-chart-config config render-to)]
+
+    (.log js/console (str "plot-pie " (-> this r/dom-node) ", "
+                          (-> this r/dom-node .-children) "|"))
+
     (.highcharts (js/$ (r/dom-node this))
                  (clj->js all-config))))
 
@@ -39,7 +44,7 @@
 
 (defn embed-pie [data options]
   (let [dats (util/process-data (get-in data [:data (get-in options [:src :extract])])
-                           (get-in options [:src :slice-at]))]
+                                (get-in options [:src :slice-at]))]
 
     ;(.log js/console (str ":pie-chart " name " " slice-at))
 
@@ -47,13 +52,14 @@
      [pie-chart
       {:chart-options
        {:title       {:text ""}
-        :plotOptions {:series  {:animation (-> options :viz :animation)}}
+        :plotOptions {:series {:animation (get-in options [:viz :animation] false)}}
+        :tooltip     (get-in options [:viz :tooltip] {})
         :series      dats}}]]))
 
 
 (widget-common/register-widget
   :pie-chart
   (fn [data options]
-      [basic/basic-widget data options
-       [:div {:style {:height "40%" :marginTop "-25px"}}
-        [embed-pie data options]]]))
+    [basic/basic-widget data options
+     [:div {:style {:height "40%" :marginTop "-25px"}}
+      [embed-pie data options]]]))

--- a/src/cljs/vanilla/widgets/pie_chart.cljs
+++ b/src/cljs/vanilla/widgets/pie_chart.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+    ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]
             [vanilla.widgets.basic-widget :as basic]
             [vanilla.widgets.util :as util]))
@@ -10,30 +10,28 @@
 
 (defn- render
   []
-  [:div {:style {:width "100%" :height "70%"}}])
+  [:div {:style {:width "100%" :height "100%"}}])
 
 (def pie-chart-config
-  {:chart {:type            "pie"
-           :backgroundColor "transparent"
-
-           :style           {:labels {
-                                      :fontFamily "monospace"
-                                      :color      "#FFFFFF"}}}
-   :yAxis {:title  {:style {:color "#000000"}}
-           :labels {:color "#ffffff"}}
-   :xAxis {:labels {:style {:color "#fff"}}}})
+  {:chart   {:type            "pie"
+             :backgroundColor "transparent"
+             :style           {:labels {
+                                        :fontFamily "monospace"
+                                        :color      "#FFFFFF"}}}
+   :yAxis   {:title  {:style {:color "#000000"}}
+             :labels {:color "#ffffff"}}
+   :xAxis   {:labels {:style {:color "#fff"}}}
+   :credits {:enabled false}})
 
 
 (defn- plot-pie [this]
   (let [config     (-> this r/props :chart-options)
-        render-to  {:render-to (r/dom-node this)}
-        all-config (merge pie-chart-config config render-to)]
+        all-config (merge pie-chart-config config)]
 
-    (.log js/console (str "plot-pie " (-> this r/dom-node) ", "
-                          (-> this r/dom-node .-children) "|"))
+    (.log js/console (str "plot-pie "))
 
-    (.highcharts (js/$ (r/dom-node this))
-                 (clj->js all-config))))
+    (js/Highcharts.Chart. (r/dom-node this)
+                          (clj->js all-config))))
 
 (defn- pie-chart
   [chart-options]
@@ -48,18 +46,17 @@
 
     ;(.log js/console (str ":pie-chart " name " " slice-at))
 
-    [:div {:style {:height "100%"}}
-     [pie-chart
-      {:chart-options
-       {:title       {:text ""}
-        :plotOptions {:series {:animation (get-in options [:viz :animation] false)}}
-        :tooltip     (get-in options [:viz :tooltip] {})
-        :series      dats}}]]))
+    [pie-chart
+     {:chart-options
+      {:title       {:text ""}
+       :plotOptions {:series {:animation (get-in options [:viz :animation] false)}}
+       :tooltip     (get-in options [:viz :tooltip] {})
+       :series      dats}}]))
 
 
 (widget-common/register-widget
   :pie-chart
   (fn [data options]
     [basic/basic-widget data options
-     [:div {:style {:height "40%" :marginTop "-25px"}}
+     [:div {:style {:width "100%"}}
       [embed-pie data options]]]))

--- a/src/cljs/vanilla/widgets/side_by_side_chart.cljs
+++ b/src/cljs/vanilla/widgets/side_by_side_chart.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :refer-macros [reaction]]
             [cljsjs.highcharts]
-            [cljsjs.jquery]
+            ;[cljsjs.jquery]
             [dashboard-clj.widgets.core :as widget-common]
             [vanilla.widgets.basic-widget :as basic]
             [vanilla.widgets.util :as util]
@@ -19,7 +19,7 @@
 
     [basic/basic-widget data options
 
-     [:div.columns {:style {:height "225px" :width "100%" :marginTop "10px"}}
+     [:div.columns {:style {:height "100%" :width "100%" :marginTop "10px"}}
 
       [:div.column.is-two-thirds {:style {:height "200px"}}
        (let [dats (util/pie->bar data

--- a/src/cljs/vanilla/widgets/simple_text.cljs
+++ b/src/cljs/vanilla/widgets/simple_text.cljs
@@ -11,12 +11,11 @@
 
    [basic/basic-widget data options
 
-    [:div (merge {:class "simple-text-widget"}
-                 {:style (-> options :wrapper :style)})
-     [:div (merge {:class "data"}
-                  {:style (-> options :data :style)})
-      [:p {:style {:paddingTop "25%"
-                   :fontSize "50px"
+    [:div {:class "simple-text-widget"}
+     [:div {:class "data"
+            :style (get-in options [:viz :style] {})}
+      [:p {:style {:fontSize "50px"
                    :font-weight "bold"
                    :color "blue"}}
+
        (get-in data [:data :text])]]]]))

--- a/src/cljs/vanilla/widgets/simple_text.cljs
+++ b/src/cljs/vanilla/widgets/simple_text.cljs
@@ -1,20 +1,23 @@
 (ns vanilla.widgets.simple-text
-    (:require [reagent.core :as r :refer [atom]]
-              [dashboard-clj.widgets.core :as widget-common]
-              [vanilla.widgets.basic-widget :as basic]))
+  (:require [reagent.core :as r :refer [atom]]
+            [dashboard-clj.widgets.core :as widget-common]
+            [vanilla.widgets.basic-widget :as basic]))
 
 
 (widget-common/register-widget
- :simple-text
- (fn [data options]
-   ;(.log js/console ":simple-text" (str data) (str options))
+  :simple-text
+  (fn [data options]
+    ;(.log js/console ":simple-text" (str data) (str options))
 
-   [basic/basic-widget data options
+    [basic/basic-widget data options
 
-    [:div {:style {:width "100%"
-                   :display :flex :align-items :center}}    ;(get-in options [:viz :style] {})}
-     [:p {:style {:fontSize    "50px"
-                  :font-weight "bold"
-                  :color       "blue"}}
+     [:div {:style {:width "100%"
+                    :text-align :center
+                    :border-style  (get-in options [:viz :debug] :none)}}
+      [:p {:style {:fontSize    "50px"
+                   :font-weight "bold"
+                   :color       "blue"}}
+                                    ;
 
-      (get-in data [:data :text])]]]))
+
+       (get-in data [:data :text])]]]))

--- a/src/cljs/vanilla/widgets/simple_text.cljs
+++ b/src/cljs/vanilla/widgets/simple_text.cljs
@@ -11,11 +11,10 @@
 
    [basic/basic-widget data options
 
-    [:div {:class "simple-text-widget"}
-     [:div {:class "data"
-            :style (get-in options [:viz :style] {})}
-      [:p {:style {:fontSize "50px"
-                   :font-weight "bold"
-                   :color "blue"}}
+    [:div {:style {:width "100%"
+                   :display :flex :align-items :center}}    ;(get-in options [:viz :style] {})}
+     [:p {:style {:fontSize    "50px"
+                  :font-weight "bold"
+                  :color       "blue"}}
 
-       (get-in data [:data :text])]]]]))
+      (get-in data [:data :text])]]]))


### PR DESCRIPTION
lots of little fussing to get:

1. dependencies opted to current (except figwheel)
1. minor tweaks to UI widget to get highchair to run inside uberjar. Requires "js/Highcharts/Chart."  see [link](https://github.com/reagent-project/reagent-cookbook/blob/master/recipes/highcharts/src/cljs/highcharts/core.cljs)
1. keep figwheel operating. Requires staying on 0.5.2 fo now, until we can figure out what in project.clj needs to change to support the current version