### PR TITLE
nRepl is once again available during development

### DIFF
--- a/dev-config.edn
+++ b/dev-config.edn
@@ -1,0 +1,10 @@
+;; WARNING
+;; The dev-config.edn file is used for local environment variables, such as database credentials.
+;; This file is listed in .gitignore and will be excluded from version control by Git.
+
+{:dev true
+ :port 5000
+ ;; when :nrepl-port is set the application starts the nREPL server on load
+ :nrepl-port 7000}
+ 
+

--- a/env/prod/resources/config.edn
+++ b/env/prod/resources/config.edn
@@ -1,0 +1,2 @@
+{:prod true
+ :port 5000}

--- a/src/clj/dashboard_clj/core.clj
+++ b/src/clj/dashboard_clj/core.clj
@@ -1,8 +1,14 @@
 (ns dashboard-clj.core
   (:require [dashboard-clj.system :as system]
-            [dashboard-clj.data-source :as ds]))
+            [dashboard-clj.data-source :as ds]
+            [vanilla.environment :refer [environment]]))
 
 
-(defn start [ds-maps {:keys [port nrepl-port] :as options}]
-  (let [data-sources (map #(ds/new-data-source %) ds-maps)]
-    (system/start port nrepl-port data-sources)))
+(defn start [ds-maps]
+
+  (let [data-sources (map #(ds/new-data-source %) ds-maps)
+        port (Integer. (or (environment :port) 5000))
+        nrepl (not (environment :prod))
+        nrepl-port (Integer. (or (environment :nrepl-port) 7000))]
+
+    (system/start port nrepl nrepl-port data-sources)))

--- a/src/clj/dashboard_clj/system.clj
+++ b/src/clj/dashboard_clj/system.clj
@@ -9,14 +9,25 @@
             [vanilla.db.core :as db]))
 
 
-(defn ->system [http-port nrepl-port data-sources]
-  (component/system-map
-   :websocket (websocket/new-websocket-server data-sources sente-web-server-adapter {})
-   :server (component/using (webserver/new-webserver routes/->http-handler http-port) [:websocket])
-   :scheduler (scheduler/new-scheduler data-sources)
-   ; TODO - reactivate nrepl for development
-   ; :nrepl (nrepl/start-server :port nrepl-port)
-   :database (db/setup-database)))
+(defn ->system [http-port nrepl nrepl-port data-sources]
+  (if nrepl
+    (do
+      (prn "starting with nrepl")
+      (component/system-map
+       :websocket (websocket/new-websocket-server data-sources sente-web-server-adapter {})
+       :server (component/using (webserver/new-webserver routes/->http-handler http-port) [:websocket])
+       :scheduler (scheduler/new-scheduler data-sources)
+       :nrepl (nrepl/start-server :port nrepl-port)
+       :database (db/setup-database)))
 
-(defn start [http-port nrepl-port data-sources]
-  (component/start (->system http-port nrepl-port data-sources)))
+    ; don't start an nrepl
+    (component/system-map
+      :websocket (websocket/new-websocket-server data-sources sente-web-server-adapter {})
+      :server (component/using (webserver/new-webserver routes/->http-handler http-port) [:websocket])
+      :scheduler (scheduler/new-scheduler data-sources)
+      :database (db/setup-database))))
+
+
+
+(defn start [http-port nrepl nrepl-port data-sources]
+  (component/start (->system http-port nrepl nrepl-port data-sources)))

--- a/src/clj/vanilla/environment.clj
+++ b/src/clj/vanilla/environment.clj
@@ -1,0 +1,9 @@
+(ns vanilla.environment
+  (:require [cprop.core :refer [load-config]]
+            [cprop.source :as source]))
+
+
+(def environment (load-config
+                   :merge
+                   [(source/from-system-props)
+                    (source/from-env)]))

--- a/src/clj/vanilla/server.clj
+++ b/src/clj/vanilla/server.clj
@@ -1,6 +1,6 @@
 (ns vanilla.server
     (:require [dashboard-clj.core :as dash]
-              [environ.core :refer [env]]
+              [vanilla.environment]
               [vanilla.fetcher]
 
               [vanilla.bubble-service]
@@ -19,8 +19,7 @@
 
 (defn start-dashboard[]
   (prn "server starting")
-  (dash/start deps/datasources {:port (Integer. (or (env :port) 5000))
-                                :nrepl-port (Integer. (or (env :nrepl-port) 7000))}))
+  (dash/start deps/datasources))
 
 (defn -main [& [port]]
   (start-dashboard))


### PR DESCRIPTION
but it is not started and does NOT cause issues in the uberjar or when deployed to docker.